### PR TITLE
fix: SpreadsheetRow 모델 오타 수정 및 호환성 개선

### DIFF
--- a/models/spreadsheet_row.py
+++ b/models/spreadsheet_row.py
@@ -1,4 +1,6 @@
 from dataclasses import dataclass
+from datetime import datetime, timedelta
+import re
 from typing import List, Optional
 
 @dataclass
@@ -10,19 +12,58 @@ class SpreadsheetRow:
     friday_date: str = ""                   # B열: 해당 주 금요일 날짜 (YYYY-MM-DD)
     
     # I, L, N, O열: 비율 및 메시지 데이터  
-    onlief_simple_ratio: str = "00.00%"     # I열: 온리프+심플치과 비율
-    leshaen_ratio: str = "00.00%"           # L열: 르샤인 비율
-    oblive_ratio: str = "00.00%"            # N열: 오블리브 비율
+    onleaf_simple_ratio: str = "00.00%"     # I열: 온리프+심플치과 비율 (오타 수정)
+    leshine_ratio: str = "00.00%"           # L열: 르샤인 비율 (오타 수정)
+    oblible_ratio: str = "00.00%"           # N열: 오블리브 비율 (오타 수정)
     full_message: str = ""                  # O열: 년도+주차(이름) + 전체 메시지
+    
+    def __post_init__(self):
+        """초기화 후 자동으로 날짜와 메시지 포맷팅"""
+        if not self.friday_date:
+            self.friday_date = self._get_friday_of_week()
+        
+        if self.full_message and not self.full_message.startswith('-'):
+            # 원본 메시지가 있고 아직 포맷팅되지 않은 경우
+            self.full_message = self._format_message_content(self.author_name, self.full_message)
+    
+    def _get_friday_of_week(self) -> str:
+        """해당 주의 금요일 날짜를 YYYY-MM-DD 형식으로 반환"""
+        today = datetime.now()
+        days_until_friday = (4 - today.weekday()) % 7  # 4 = 금요일
+        if today.weekday() > 4:  # 토요일(5) 또는 일요일(6)인 경우 다음 주 금요일
+            days_until_friday = 7 - today.weekday() + 4
+        friday = today + timedelta(days=days_until_friday)
+        return friday.strftime("%Y-%m-%d")
+    
+    def _format_message_content(self, user_name: str, message_content: str) -> str:
+        """메시지 내용을 제목과 함께 포맷팅"""
+        today = datetime.now()
+        year = today.year
+        month = today.month
+        
+        # 해당 월의 첫 번째 날 구하기
+        first_day = datetime(year, month, 1)
+        # 해당 월 첫 번째 날의 요일 (0=월요일)
+        first_weekday = first_day.weekday()
+        
+        # 현재 날짜가 몇 번째 주인지 계산
+        current_day = today.day
+        week_number = ((current_day - 1 + first_weekday) // 7) + 1
+        
+        # 메시지에서 "이름:xxx" 패턴 제거
+        cleaned_message = re.sub(r'이름:\S+\s*', '', message_content).strip()
+        
+        title = f"-{year} {month}월 {week_number}주차({user_name})"
+        return f"{title}\n{cleaned_message}"
     
     def get_column_data(self) -> dict:
         """필요한 열의 데이터만 반환"""
         return {
             'A': self.author_name,
             'B': self.friday_date,
-            'I': self.onlief_simple_ratio,
-            'L': self.leshaen_ratio,
-            'N': self.oblive_ratio,
+            'I': self.onleaf_simple_ratio,
+            'L': self.leshine_ratio,
+            'N': self.oblible_ratio,
             'O': self.full_message
         }
     
@@ -34,8 +75,8 @@ class SpreadsheetRow:
         return cls(
             author_name=parsed_data.get('author_name', '홍길동'),
             friday_date=parsed_data.get('friday_date', ''),
-            onlief_simple_ratio=ratios.get('onlief_simple_ratio', '00.00%'),
-            leshaen_ratio=ratios.get('leshaen_ratio', '00.00%'),
-            oblive_ratio=ratios.get('oblive_ratio', '00.00%'),
+            onleaf_simple_ratio=ratios.get('onleaf_simple_ratio', '00.00%'),
+            leshine_ratio=ratios.get('leshine_ratio', '00.00%'),
+            oblible_ratio=ratios.get('oblible_ratio', '00.00%'),
             full_message=parsed_data.get('o_column_data', '')
         )

--- a/services/sheets_service.py
+++ b/services/sheets_service.py
@@ -72,24 +72,29 @@ class SheetsService:
         title = f"-{year} {month}월 {week_number}주차({user_name})"
         return f"{title}\n{cleaned_message}"
     
-    def append_row(self, data: dict):
+    def append_row(self, data):
         """빈 행에 필요한 열만 데이터 입력 (A, B, I, L, N, O열)"""
         try:
             # 첫 번째 빈 행 찾기
             target_row = self.find_first_empty_row()
             
-            # 필요한 열의 데이터만 준비
-            column_data = {
-                'A': data["slack_user_name"],                    # A열: 사용자명
-                'B': self._get_friday_of_week(),                 # B열: 해당 주 금요일
-                'I': data["onleaf_simple_ratio"],                # I열: 온리프/심플 비율
-                'L': data["leshine_ratio"],                      # L열: 르샤인 비율
-                'N': data["oblible_ratio"],                      # N열: 오블리브 비율
-                'O': self._format_message_content(               # O열: 제목 + 원본 메시지
-                    data["slack_user_name"], 
-                    data["slack_message_content"]
-                )
-            }
+            # SpreadsheetRow 객체인지 dict인지 확인하여 처리
+            if isinstance(data, SpreadsheetRow):
+                # SpreadsheetRow 객체인 경우
+                column_data = data.get_column_data()
+            else:
+                # dict인 경우 (기존 방식 호환)
+                column_data = {
+                    'A': data["slack_user_name"],                    # A열: 사용자명
+                    'B': self._get_friday_of_week(),                 # B열: 해당 주 금요일
+                    'I': data["onleaf_simple_ratio"],                # I열: 온리프/심플 비율
+                    'L': data["leshine_ratio"],                      # L열: 르샤인 비율
+                    'N': data["oblible_ratio"],                      # N열: 오블리브 비율
+                    'O': self._format_message_content(               # O열: 제목 + 원본 메시지
+                        data["slack_user_name"], 
+                        data["slack_message_content"]
+                    )
+                }
             
             # 각 열별로 개별 업데이트
             for column, value in column_data.items():

--- a/test_fix.py
+++ b/test_fix.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""
+SpreadsheetRow 모델 수정 테스트
+"""
+
+from models.spreadsheet_row import SpreadsheetRow
+
+def test_spreadsheet_row_creation():
+    """SpreadsheetRow 생성 테스트"""
+    print("=== SpreadsheetRow 생성 테스트 ===")
+    
+    # 기본 생성
+    row1 = SpreadsheetRow(
+        author_name="이은상",
+        onleaf_simple_ratio="1.92%",
+        leshine_ratio="4.81%",
+        oblible_ratio="93.27%",
+        full_message="이름:이은상 온리프 1시간 르샤인 2.5시간 오블리브 48.5시간"
+    )
+    
+    print(f"작성자: {row1.author_name}")
+    print(f"금요일 날짜: {row1.friday_date}")
+    print(f"온리프/심플 비율: {row1.onleaf_simple_ratio}")
+    print(f"르샤인 비율: {row1.leshine_ratio}")
+    print(f"오블리브 비율: {row1.oblible_ratio}")
+    print(f"전체 메시지:\n{row1.full_message}")
+    print()
+
+def test_column_data():
+    """열 데이터 반환 테스트"""
+    print("=== 열 데이터 반환 테스트 ===")
+    
+    row = SpreadsheetRow(
+        author_name="홍길동",
+        onleaf_simple_ratio="10.50%",
+        leshine_ratio="20.30%",
+        oblible_ratio="69.20%",
+        full_message="테스트 메시지입니다"
+    )
+    
+    column_data = row.get_column_data()
+    for column, value in column_data.items():
+        print(f"{column}열: {value}")
+    print()
+
+def test_from_parsed_data():
+    """파싱된 데이터로부터 생성 테스트"""
+    print("=== 파싱된 데이터로부터 생성 테스트 ===")
+    
+    parsed_data = {
+        'author_name': '김철수',
+        'ratios': {
+            'onleaf_simple_ratio': '5.25%',
+            'leshine_ratio': '15.75%',
+            'oblible_ratio': '79.00%'
+        },
+        'o_column_data': '이름:김철수 온리프 2시간 르샤인 6시간 오블리브 30시간'
+    }
+    
+    row = SpreadsheetRow.from_parsed_data(parsed_data)
+    print(f"작성자: {row.author_name}")
+    print(f"온리프/심플: {row.onleaf_simple_ratio}")
+    print(f"르샤인: {row.leshine_ratio}")
+    print(f"오블리브: {row.oblible_ratio}")
+    print(f"전체 메시지:\n{row.full_message}")
+    print()
+
+def test_dict_compatibility():
+    """dict 호환성 테스트"""
+    print("=== dict 호환성 테스트 ===")
+    
+    # dict 형태 데이터
+    dict_data = {
+        "slack_user_name": "박영희",
+        "onleaf_simple_ratio": "3.14%",
+        "leshine_ratio": "12.86%", 
+        "oblible_ratio": "84.00%",
+        "slack_message_content": "이름:박영희 온리프 1.5시간 르샤인 6시간 오블리브 40시간"
+    }
+    
+    print("dict 데이터:")
+    for key, value in dict_data.items():
+        print(f"  {key}: {value}")
+    print()
+
+if __name__ == "__main__":
+    test_spreadsheet_row_creation()
+    test_column_data()
+    test_from_parsed_data()
+    test_dict_compatibility()
+    print("✅ 모든 테스트 완료")

--- a/tests/test_spreadsheet_row.py
+++ b/tests/test_spreadsheet_row.py
@@ -9,9 +9,9 @@ class TestSpreadsheetRow(unittest.TestCase):
         row = SpreadsheetRow(
             author_name="테스트사용자",
             friday_date="2025-09-05",
-            onlief_simple_ratio="1.92%",
-            leshaen_ratio="4.81%",
-            oblive_ratio="93.27%",
+            onleaf_simple_ratio="1.92%",
+            leshine_ratio="4.81%",
+            oblible_ratio="93.27%",
             full_message="- 2025 9월 1주차(테스트사용자)\n테스트 메시지"
         )
         
@@ -30,9 +30,9 @@ class TestSpreadsheetRow(unittest.TestCase):
             'author_name': '홍길동',
             'friday_date': '2025-09-12',
             'ratios': {
-                'onlief_simple_ratio': '10.00%',
-                'leshaen_ratio': '20.00%',
-                'oblive_ratio': '70.00%'
+                'onleaf_simple_ratio': '10.00%',
+                'leshine_ratio': '20.00%',
+                'oblible_ratio': '70.00%'
             },
             'o_column_data': '- 2025 9월 2주차(홍길동)\n테스트'
         }
@@ -41,21 +41,38 @@ class TestSpreadsheetRow(unittest.TestCase):
         
         self.assertEqual(row.author_name, '홍길동')
         self.assertEqual(row.friday_date, '2025-09-12')
-        self.assertEqual(row.onlief_simple_ratio, '10.00%')
-        self.assertEqual(row.leshaen_ratio, '20.00%')
-        self.assertEqual(row.oblive_ratio, '70.00%')
+        self.assertEqual(row.onleaf_simple_ratio, '10.00%')
+        self.assertEqual(row.leshine_ratio, '20.00%')
+        self.assertEqual(row.oblible_ratio, '70.00%')
         self.assertEqual(row.full_message, '- 2025 9월 2주차(홍길동)\n테스트')
     
     def test_default_values(self):
-        """기본값 테스트"""
+        """기본값 테스트 (자동 날짜 설정 고려)"""
         row = SpreadsheetRow()
         
         self.assertEqual(row.author_name, "홍길동")
-        self.assertEqual(row.friday_date, "")
-        self.assertEqual(row.onlief_simple_ratio, "00.00%")
-        self.assertEqual(row.leshaen_ratio, "00.00%")
-        self.assertEqual(row.oblive_ratio, "00.00%")
+        # friday_date는 자동으로 설정되므로 빈 문자열이 아님
+        self.assertNotEqual(row.friday_date, "")
+        self.assertTrue(row.friday_date.startswith("2025-"))
+        self.assertEqual(row.onleaf_simple_ratio, "00.00%")
+        self.assertEqual(row.leshine_ratio, "00.00%")
+        self.assertEqual(row.oblible_ratio, "00.00%")
         self.assertEqual(row.full_message, "")
+    
+    def test_auto_formatting(self):
+        """자동 포맷팅 테스트"""
+        row = SpreadsheetRow(
+            author_name="김철수",
+            full_message="이름:김철수 온리프 2시간 르샤인 5시간"
+        )
+        
+        # 자동으로 날짜가 설정되어야 함
+        self.assertNotEqual(row.friday_date, "")
+        
+        # 메시지가 자동으로 포맷팅되어야 함
+        self.assertTrue(row.full_message.startswith("-2025"))
+        self.assertIn("김철수", row.full_message)
+        self.assertNotIn("이름:김철수", row.full_message)  # 이름 패턴 제거 확인
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## 문제점
기존 과  브랜치 간의 로직 충돌 발견:

### 1. 필드명 오타
-  → 
-  →   
-  → 

### 2. 데이터 타입 불일치
- SheetsService가 dict를 기대하지만 SpreadsheetRow 모델도 존재

## 해결 방안

### ✅ 오타 수정
- SpreadsheetRow 모델의 모든 필드명 오타 수정
- 테스트 케이스도 함께 업데이트

### ✅ 호환성 개선
- SheetsService.append_row()가 SpreadsheetRow와 dict 모두 지원
- 기존 코드와의 하위 호환성 유지

### ✅ 기능 강화
- SpreadsheetRow에 자동 날짜 설정 기능 추가
- 자동 메시지 포맷팅 기능 추가 (이름: 패턴 제거 포함)

## 테스트 결과


## 변경사항
- [x] SpreadsheetRow 모델 오타 수정
- [x] SheetsService 호환성 개선  
- [x] 자동 포맷팅 기능 추가
- [x] 테스트 케이스 업데이트
- [x] 모든 테스트 통과 확인